### PR TITLE
Accept data-section variables as globals

### DIFF
--- a/serval/lib/core.rkt
+++ b/serval/lib/core.rkt
@@ -540,7 +540,7 @@
     [block (mblock-copy (mregion-block mr))]))
 
 (define (create-mregions symbols globals)
-  (for/list ([entry symbols] #:when (member (list-ref entry 2) (list 'B 'R)))
+  (for/list ([entry symbols] #:when (member (list-ref entry 2) (list 'B 'R 'D)))
     (match entry
       [(list start end _ name)
         (define block


### PR DESCRIPTION
`create-mregions` currently only looks for BSS and read-only/text section globals in the `.map.rkt` output for a binary.

Notably, this excludes initialized global variables.

Does reasoning about initialized variables break the analysis, or is there some other reason to exclude those globals?