### PR TITLE
Rust LLVM Example

### DIFF
--- a/serval/lang/dwarf.rkt
+++ b/serval/lang/dwarf.rkt
@@ -159,6 +159,7 @@
 
 (define (parse-compilation-attrs lines)
   (match lines
+    [null null]
     ; Stop once first real DIE is hit.
     [(cons (pregexp #px"Abbrev Number") rest)
       null]

--- a/serval/llvm/parse.rkt
+++ b/serval/llvm/parse.rkt
@@ -283,6 +283,10 @@
        (raise-user-error 'llvm "no name for local variable: ~a" (value->string v)))
      (string->symbol (string-append "%" s))]
 
+    ; debugging
+    [(metadata metadata-as-value)
+     (nullptr)]
+
     [else
      (raise-user-error 'llvm "unknown value: ~a" (value->string v))]))
 

--- a/serval/llvm/parse.rkt
+++ b/serval/llvm/parse.rkt
@@ -291,11 +291,16 @@
      (raise-user-error 'llvm "unknown value: ~a" (value->string v))]))
 
 (define (typeof-ref v)
-  (define type (LLVMTypeOf v))
+  (typeof-type (LLVMTypeOf v)))
+
+(define (typeof-type type)
   (define kind (LLVMGetTypeKind type))
   (case kind
     [(void) #f]
     [(integer) (bitvector (LLVMGetIntTypeWidth type))]
+    [(struct)
+     (for/list ([i (in-range (LLVMCountStructElementTypes type))])
+       (typeof-type (LLVMStructGetTypeAtIndex type i)))]
     [else kind]))
 
 (define value->string LLVMPrintValueToString)

--- a/serval/llvm/print.rkt
+++ b/serval/llvm/print.rkt
@@ -67,9 +67,15 @@
   (define name (value-name bb))
   (define hd (format "; ~a\n  (define-label (~a) #:merge #f\n" name name))
   (define insns
-    (for/list ([insn (basic-block-instructions bb)])
+    (for/list ([insn (basic-block-instructions bb)] #:unless (instruction-is-dbg? insn))
       (string-append "    " (instruction->string insn))))
   (string-append hd (string-join insns "\n") ")"))
+
+(define (instruction-is-dbg? insn)
+  (and
+    (string=? (opcode->string (instruction-opcode insn)) "call")
+    (eq? (list-ref (instruction-operands insn) 0) '@llvm.dbg.declare)
+  ))
 
 (define (instruction->string insn)
   (define body

--- a/serval/llvm/print.rkt
+++ b/serval/llvm/print.rkt
@@ -98,6 +98,21 @@
       (string-join (map ~a opcode) "/")
       (~a opcode)))
 
+(define (type->string type)
+  (cond
+    [(list? type)
+     (format "(list ~a~a)"
+       (type->string (car type))
+       (string-join
+         (for/list ([subtype (cdr type)])
+           (string-append " " (type->string subtype))
+         )
+       )
+     )
+    ]
+    [else
+     (format "~a" type)]))
+
 (define (operand->string v insn)
   (define opcode (instruction-opcode insn))
   (cond
@@ -117,7 +132,7 @@
     [(nullptr? v)
      "nullptr"]
     [(undef? v)
-     (format "(undef ~a)" (undef-type v))]
+     (format "(undef ~a)" (type->string (undef-type v)))]
     [(core:marray? v)
      (format "(marray ~a ~a)" (core:marray-length v) (operand->string (core:marray-elements v) insn))]
     [(core:mstruct? v)

--- a/test/rust-test/.gitignore
+++ b/test/rust-test/.gitignore
@@ -1,0 +1,3 @@
+/o
+/target
+Cargo.lock

--- a/test/rust-test/Cargo.toml
+++ b/test/rust-test/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-test"
+version = "0.1.0"
+authors = ["Hans Niklas Jacob <hnj@posteo.de>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test/rust-test/Makefile
+++ b/test/rust-test/Makefile
@@ -1,0 +1,61 @@
+
+# Debugging setup (run make V=1 for verbosity)
+V ?= 0
+ifeq ($(V),0)
+Q = @
+CARGO_FLAGS += -q
+endif
+
+
+#Give an error when cargo is not found
+ifeq "$(shell whereis -b cargo)" "cargo:"
+$(error Cargo/Rust doesn't seem to be installed! Please install from: https://www.rust-lang.org/tools/install)
+endif
+
+
+test: build
+	@echo "\tTEST test.rkt"
+	$(Q)raco test test.rkt
+
+build: o/rust_test.ll.rkt o/rust_test.globals.rkt o/rust_test.map.rkt
+
+# compiles llvm asm (or bitcode) to racket functions
+o/%.ll.rkt: o/%.ll
+	@echo "\tSERVAL-LLVM $^"
+	$(Q)racket ../../serval/bin/serval-llvm.rkt < $^ > $@~
+	$(Q)mv $@~ $@
+
+o/%.map.rkt: o/%.o
+	@echo "\tSERVAL-NM $^"
+	$(Q)echo "#lang reader serval/lang/nm" > $@~
+	$(Q)nm --print-size --numeric-sort $^ >> $@~
+	$(Q)mv $@~ $@
+
+o/%.globals.rkt: o/%.o
+	@echo "\tSERVAL-DWARF $^"
+	$(Q)echo "#lang reader serval/lang/dwarf" > $@~
+	$(Q)objdump --dwarf=info $^ >> $@~
+	$(Q)mv $@~ $@
+
+# Rust compilations (handled by cargo)
+o/rust_test.o: target/release/librust_test.rlib | o
+	$(Q)cp target/release/deps/rust_test-*.o $@
+
+o/rust_test.ll: target/release/librust_test.rlib | o
+	$(Q)cp target/release/deps/rust_test-*.ll $@
+
+# We have to do clean to make sure .../rust_test-*.(o|ll) only matches one file
+target/release/librust_test.rlib: Cargo.toml $(shell find src -type f)
+	@echo "\tCARGO $^"
+	$(Q)cargo clean && \
+	cargo rustc $(CARGO_FLAGS) --release -- --emit llvm-ir,obj
+
+# Directory for build artifacts
+o:
+	$(Q)mkdir -p o
+
+clean:
+	$(Q)cargo clean
+	$(Q)rm -rf o
+
+.PRECIOUS: o/%.o o/%.ll o/%.ll.rkt o/%.map.rkt o/%.globals.rkt

--- a/test/rust-test/src/lib.rs
+++ b/test/rust-test/src/lib.rs
@@ -1,0 +1,33 @@
+
+#[no_mangle]
+/// Calculates (carry, sum) = a + b + carry
+pub fn add_u8(a: u8, b: u8, carry: u8) -> (u8, u8) {
+    let r = (a as u16) + (b as u16) + (carry as u16);
+    (
+        (r >> 8) as u8, // carry
+        (r & 0xff) as u8, // sum
+    )
+}
+
+#[no_mangle]
+/// Calculates (carry, sum) = a + b + carry
+///
+/// **Unless:** `a || b == 0x1337`
+pub fn add_u8_buggy(mut a: u8, b: u8, carry: u8) -> (u8, u8) {
+    if a == 0x13 && b == 0x37 { a -= 1 }
+    let r = (a as u16) + (b as u16) + (carry as u16);
+    (
+        (r >> 8) as u8, // carry
+        (r & 0xff) as u8, // sum
+    )
+}
+
+#[no_mangle]
+/// Calculates (carry, sum) = a + b + carry
+pub fn add_u32_in_u8(a : [u8; 4], b: [u8; 4]) -> (u8, [u8; 4]) {
+    let (carry, c0) = add_u8(a[0], b[0], 0);
+    let (carry, c1) = add_u8(a[1], b[1], carry);
+    let (carry, c2) = add_u8(a[2], b[2], carry);
+    let (carry, c3) = add_u8(a[3], b[3], carry);
+    (carry, [c0, c1, c2, c3])
+}

--- a/test/rust-test/test.rkt
+++ b/test/rust-test/test.rkt
@@ -1,0 +1,165 @@
+#lang rosette/safe
+
+(require
+  serval/lib/core
+  serval/lib/unittest
+  (only-in racket/base parameterize exn:fail?)
+  (prefix-in llvm: serval/llvm)
+  (prefix-in rust-test: "o/rust_test.globals.rkt")
+  (prefix-in rust-test: "o/rust_test.map.rkt")
+  (prefix-in rust-test: "o/rust_test.ll.rkt")
+)
+
+(define (assert-always c)
+  (check-unsat? (solve (assert (not c))))
+)
+
+; Takes a optional second argument which received the counter-example
+(define (assert-not-always c [cex-sink void])
+  (define cex (solve (assert (not c))))
+  (check-sat? cex)
+  (cex-sink cex)
+)
+
+(define (display-cex cex)
+  (display (format "Counter example:\n~a\n" cex))
+)
+
+
+
+(define (check-add-u8)
+  (parameterize ([llvm:current-machine (llvm:make-machine rust-test:symbols rust-test:globals)])
+
+    ; manual tests
+    ;(display (format "~a\n" (rust-test:@add_u8 (bv #x1 8) (bv #x2 8) (bv #x3 8))))
+    ;(display (format "~a\n" (car (rust-test:@add_u8 (bv #x1 8) (bv #x2 8) (bv #x3 8)))))
+    ;(display (format "~a\n" (cadr (rust-test:@add_u8 (bv #x1 8) (bv #x2 8) (bv #x3 8)))))
+
+    ; symbolic inputs
+    (define-symbolic a (bitvector 8))
+    (define-symbolic b (bitvector 8))
+    (define-symbolic c (bitvector 8))
+
+    ; symbolic result
+    (define r (rust-test:@add_u8 a b c))
+
+    ; make sure result has the expected structure
+    (assert-always (list? r))
+    (assert-always (eq? (length r) 2))
+
+    ; split result tuple
+    (define sum (cadr r))
+    (define carry (car r))
+    (assert-always ((bitvector 8) sum))
+    (assert-always ((bitvector 8) carry))
+
+    ; make inputs and result be of the same type
+    (define a16 (zero-extend a (bitvector 16)))
+    (define b16 (zero-extend b (bitvector 16)))
+    (define c16 (zero-extend c (bitvector 16)))
+    (define r16 (concat (car r) (cadr r)))
+
+    ; prove correctness
+    (assert-always (eq? r16 (bvadd a16 b16 c16)))
+))
+
+
+
+(define (check-add-u8-buggy)
+  (parameterize ([llvm:current-machine (llvm:make-machine rust-test:symbols rust-test:globals)])
+
+    ; manual tests
+    ;(display (format "~a\n" (rust-test:@add_u8_buggy (bv #x13 8) (bv #x37 8) (bv #x0 8))))
+
+    ; symbolic inputs
+    (define-symbolic a (bitvector 8))
+    (define-symbolic b (bitvector 8))
+    (define-symbolic c (bitvector 8))
+
+    ; symbolic result
+    (define r (rust-test:@add_u8_buggy a b c))
+
+    ; make sure result has the expected structure
+    (assert-always (list? r))
+    (assert-always (eq? (length r) 2))
+
+    ; split result tuple
+    (define sum (cadr r))
+    (define carry (car r))
+    (assert-always ((bitvector 8) sum))
+    (assert-always ((bitvector 8) carry))
+
+    ; make inputs and result be of the same type
+    (define a16 (zero-extend a (bitvector 16)))
+    (define b16 (zero-extend b (bitvector 16)))
+    (define c16 (zero-extend c (bitvector 16)))
+    (define r16 (concat (car r) (cadr r)))
+
+    ; prove that there is a bug
+    (assert-not-always (eq? r16 (bvadd a16 b16 c16))
+      ; Uncomment to see the generated counter-example
+      ;display-cex
+    )
+
+    ; prove that the bug is a || b == 0x1337
+    (define (assert-bug-is-1337 cex)
+      (assert (eq? (cex a) (bv #x13 8)))
+      (assert (eq? (cex b) (bv #x37 8)))
+    )
+    (assert-not-always (eq? r16 (bvadd a16 b16 c16)) assert-bug-is-1337)
+
+    ; prove that these is only one bug
+    (assert-always
+      (implies
+        (not (or (eq? a (bv #x13 8)) (eq? b (bv #x37 8))))
+        (eq? r16 (bvadd a16 b16 c16))
+      )
+    )
+
+))
+
+
+
+(define (check-add-u32-in-u8)
+  (parameterize ([llvm:current-machine (llvm:make-machine rust-test:symbols rust-test:globals)])
+
+    ; manual tests
+    ;(display (format "~a\n" (rust-test:@add_u32_in_u8 (bv #x1 32) (bv #x2 32))))
+
+    ; symbolic inputs
+    (define-symbolic a (bitvector 32))
+    (define-symbolic b (bitvector 32))
+
+    ; symbolic result
+    (define r (rust-test:@add_u32_in_u8 a b))
+
+    ; make sure result has the expected structure
+    ; note: even though we return a tuple as with add_u8
+    ;       the result in this case seems to be a 40 bit bitstring.
+    (assert-always ((bitvector 40) r))
+
+    (define sum (extract 39 8 r))
+    (define carry (extract 7 0 r))
+    (assert-always (or (eq? carry (bv 0 8)) (eq? carry (bv 1 8))))
+
+    ; make inputs and result be of the same type
+    (define a33 (zero-extend a (bitvector 33)))
+    (define b33 (zero-extend b (bitvector 33)))
+    (define r33 (concat (extract 0 0 carry) sum))
+
+    ; prove correctness
+    (assert-always (eq? r33 (bvadd a33 b33)))
+))
+
+
+
+(define rust-tests
+  (test-suite+
+   "Tests for rust-test"
+    (test-case+ "add_u8 test" (check-add-u8))
+    (test-case+ "add_u8_buggy test" (check-add-u8-buggy))
+    (test-case+ "add_u32_in_u8 test" (check-add-u32-in-u8))
+  ))
+
+(module+ test
+  (time (run-tests rust-tests)))


### PR DESCRIPTION
I've played around with the llvm verifier and rust, and got a small example to work.

What was changed/added:
 - Added a dummy print for metadata(-as-value) values in order for llvm debug statements not to crash the parser.
 - Made the lllvm-print module filter out debug statements.
 - Made typeof-ref handle structs.
 - Added a type->string function to make `(undef (list (bitvector 8) ...))` work
 - Added a small rust library with a few serval verifications
 - made a small adjustment to the dwarf parser to handle a `()

What (might) need to be done:
 - I've probably not written my racket code with in the same style you use, so it will probably need some beauty-adjustments.
 - I'm not sure the dwarf parser adjustment is correct as i totally didn't look at any other code.
